### PR TITLE
Updates for 2.3.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -66,7 +66,7 @@ jobs:
   run_test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
     - name: Run tests

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,18 +17,28 @@
 		<!-- Treat all warnings as errors -->
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 
-
-
-
 		<!-- ============================================================================ -->
 		<!-- packaging info -->
 		<!-- ============================================================================ -->
-		<Version>2.2.0</Version>
+		<Version>2.3.0</Version>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<EnablePackageValidation>true</EnablePackageValidation>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<PackageTags>syrx;data access;orm;micro-orm</PackageTags>
-		<PackageReleaseNotes>Updated to .NET8.0.</PackageReleaseNotes>
+		<PackageReleaseNotes>
+			# Minor release
+			## Syrx.Commanders.Databases.Settings.Readers
+			* Removed redundant references.
+
+			## Syrx.Commander.Databases.Settings.Extensions
+			* Marked Evalute method as private.
+
+			## Syrx.Commanders.Databases.Settings.Extensions.Json
+			* Added `UseFile` extension method to provide better syntactic support.
+
+			## Syrx.Commanders.Databases.Settings.Extensions.Xml
+			* Added `UseFile` extension method to provide better syntactic support.
+		</PackageReleaseNotes>
 		
 		<!-- ============================================================================ -->
 		<!-- organization info -->

--- a/Syrx.Commanders.Databases.sln
+++ b/Syrx.Commanders.Databases.sln
@@ -69,6 +69,16 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Syrx.Commanders.Databases.T
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Syrx.Commanders.Databases.Tests.Unit", "tests\unit\Syrx.Commanders.Databases.Tests.Unit\Syrx.Commanders.Databases.Tests.Unit.csproj", "{71185BE7-919D-4E24-AC2F-86B95B6457CD}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".github", ".github", "{383C4438-FEB7-4797-90D1-8C9DC20FB2A5}"
+	ProjectSection(SolutionItems) = preProject
+		.github\dependabot.yml = .github\dependabot.yml
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{6C8F7C7B-BAEA-4918-A204-1C91BCF0651D}"
+	ProjectSection(SolutionItems) = preProject
+		.github\workflows\publish.yml = .github\workflows\publish.yml
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -196,5 +206,7 @@ Global
 		{024675DD-4FC1-41D2-AD34-C83D3E767A17} = {5B0FA313-655F-466D-8376-E126871A30E2}
 		{512E9A90-AD79-4497-9526-BF1076A11DCF} = {5B0FA313-655F-466D-8376-E126871A30E2}
 		{71185BE7-919D-4E24-AC2F-86B95B6457CD} = {5B0FA313-655F-466D-8376-E126871A30E2}
+		{383C4438-FEB7-4797-90D1-8C9DC20FB2A5} = {62B696A9-D903-4211-AE85-C1198FF372E4}
+		{6C8F7C7B-BAEA-4918-A204-1C91BCF0651D} = {383C4438-FEB7-4797-90D1-8C9DC20FB2A5}
 	EndGlobalSection
 EndGlobal

--- a/src/Syrx.Commanders.Databases.Settings.Extensions.Json/ServiceCollectionExtensions.cs
+++ b/src/Syrx.Commanders.Databases.Settings.Extensions.Json/ServiceCollectionExtensions.cs
@@ -1,12 +1,12 @@
 ﻿using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using System;
 using static Syrx.Validation.Contract;
 
 namespace Syrx.Commanders.Databases.Settings.Extensions.Json
 {
     public static class ServiceCollectionExtensions
     {
+        //[Obsolete("This method is deprecated and will be removed in the 3.0.0 version.", true)]
         public static IServiceCollection AddSyrxJsonFile(
             this IServiceCollection services,
             IConfigurationBuilder builder,
@@ -18,5 +18,7 @@ namespace Syrx.Commanders.Databases.Settings.Extensions.Json
             builder?.AddJsonFile(fileName);
             return services;
         }
+
+        
     }
 }

--- a/src/Syrx.Commanders.Databases.Settings.Extensions.Json/Syrx.Commanders.Databases.Settings.Extensions.Json.csproj
+++ b/src/Syrx.Commanders.Databases.Settings.Extensions.Json/Syrx.Commanders.Databases.Settings.Extensions.Json.csproj
@@ -8,6 +8,7 @@
 		<PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.0" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
+		<PackageReference Include="Syrx.Extensions" Version="2.*" />
 		<PackageReference Include="Syrx.Validation" Version="2.*" />
 	</ItemGroup>
 

--- a/src/Syrx.Commanders.Databases.Settings.Extensions.Json/UseFileExtensions.cs
+++ b/src/Syrx.Commanders.Databases.Settings.Extensions.Json/UseFileExtensions.cs
@@ -1,0 +1,19 @@
+﻿using Microsoft.Extensions.Configuration;
+using Syrx.Extensions;
+using static Syrx.Validation.Contract;
+
+namespace Syrx.Commanders.Databases.Settings.Extensions.Json
+{
+    public static class UseFileExtensions
+    {
+        public static SyrxBuilder UseFile(this SyrxBuilder factory, string fileName, IConfigurationBuilder builder)
+        {
+            Throw<ArgumentNullException>(builder != null, $"ConfigurationBuilder is null! Check bootstrap.");
+            Throw<ArgumentNullException>(!string.IsNullOrWhiteSpace(fileName), nameof(fileName));
+
+            builder?.AddJsonFile(fileName);
+
+            return factory;
+        }
+    }
+}

--- a/src/Syrx.Commanders.Databases.Settings.Extensions.Xml/ServiceCollectionExtensions.cs
+++ b/src/Syrx.Commanders.Databases.Settings.Extensions.Xml/ServiceCollectionExtensions.cs
@@ -6,6 +6,7 @@ namespace Syrx.Commanders.Databases.Settings.Extensions.Xml
 {
     public static class ServiceCollectionExtensions
     {
+        //[Obsolete("This method is deprecated and will be removed in the 3.0.0 version.", false)]
         public static IServiceCollection AddSyrxXmlFile(
             this IServiceCollection services,
             IConfigurationBuilder builder,

--- a/src/Syrx.Commanders.Databases.Settings.Extensions.Xml/Syrx.Commanders.Databases.Settings.Extensions.Xml.csproj
+++ b/src/Syrx.Commanders.Databases.Settings.Extensions.Xml/Syrx.Commanders.Databases.Settings.Extensions.Xml.csproj
@@ -7,6 +7,7 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="9.0.0" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
+		<PackageReference Include="Syrx.Extensions" Version="2.*" />
 		<PackageReference Include="Syrx.Validation" Version="2.*" />
 	</ItemGroup>
 

--- a/src/Syrx.Commanders.Databases.Settings.Extensions.Xml/UseFileExtensions.cs
+++ b/src/Syrx.Commanders.Databases.Settings.Extensions.Xml/UseFileExtensions.cs
@@ -1,0 +1,19 @@
+﻿using Microsoft.Extensions.Configuration;
+using Syrx.Extensions;
+using static Syrx.Validation.Contract;
+
+namespace Syrx.Commanders.Databases.Settings.Extensions.Xml
+{
+    public static class UseFileExtensions
+    {
+        public static SyrxBuilder UseFile(this SyrxBuilder factory, string fileName, IConfigurationBuilder builder)
+        {
+            Throw<ArgumentNullException>(builder != null, $"ConfigurationBuilder is null! Check bootstrap.");
+            Throw<ArgumentNullException>(!string.IsNullOrWhiteSpace(fileName), nameof(fileName));
+
+            builder?.AddXmlFile(fileName);
+
+            return factory;
+        }
+    }
+}

--- a/src/Syrx.Commanders.Databases.Settings.Extensions/CommanderSettingsBuilder.cs
+++ b/src/Syrx.Commanders.Databases.Settings.Extensions/CommanderSettingsBuilder.cs
@@ -51,7 +51,7 @@
             return this;
         }
 
-        public void Evaluate(NamespaceSetting option)
+        private void Evaluate(NamespaceSetting option)
         {
             // pretty sure this can be done more elegantly. 
             if (_settings.TryGetValue(option.Namespace, out var ns))

--- a/src/Syrx.Commanders.Databases.Settings.Readers/Syrx.Commanders.Databases.Settings.Readers.csproj
+++ b/src/Syrx.Commanders.Databases.Settings.Readers/Syrx.Commanders.Databases.Settings.Readers.csproj
@@ -5,8 +5,6 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Options" Version="9.0.0" />
 		<PackageReference Include="Syrx.Readers" Version="2.*" />
 	</ItemGroup>
 

--- a/tests/unit/Syrx.Commanders.Databases.Connectors.Extensions.Tests.Unit/ServiceCollectionExtensionsTests/AddDatabaseConnector.cs
+++ b/tests/unit/Syrx.Commanders.Databases.Connectors.Extensions.Tests.Unit/ServiceCollectionExtensionsTests/AddDatabaseConnector.cs
@@ -1,9 +1,6 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
-using Moq;
 using Syrx.Commanders.Databases.Settings;
-using Syrx.Commanders.Databases.Tests.Extensions;
 using System.Data;
-using System.Data.Common;
 using static Xunit.Assert;
 
 namespace Syrx.Commanders.Databases.Connectors.Extensions.Tests.Unit.ServiceCollectionExtensionsTests
@@ -34,37 +31,4 @@ namespace Syrx.Commanders.Databases.Connectors.Extensions.Tests.Unit.ServiceColl
         }
 
     }
-
-    public class AddProvider
-    {
-        private readonly IServiceCollection _services;
-
-        public AddProvider()
-        {
-            _services = new ServiceCollection();
-        }
-
-        [Fact]
-        public void NullProviderThrowsArgumentNullException()
-        {
-            var result = Throws<ArgumentNullException>(() => _services.AddProvider(null));
-            result.HasMessage("The DbProviderFactory delegate cannot be null. (Parameter 'providerFactory')");
-        }
-
-        [Fact]
-        public void Successfully()
-        {
-            var connection = new Mock<DbConnection>();
-            var dbProviderFactory = new Mock<DbProviderFactory>();
-            dbProviderFactory.Setup(x => x.CreateConnection()).Returns(connection.Object);
-
-            Func<DbProviderFactory> factory = () => dbProviderFactory.Object;
-            var result = _services.AddProvider(factory);
-
-            var provider = _services.BuildServiceProvider();
-            var resolved = provider.GetService<Func<DbProviderFactory>>();
-            NotNull(resolved);
-            Same(factory, resolved);
-        }
-    }    
 }

--- a/tests/unit/Syrx.Commanders.Databases.Connectors.Extensions.Tests.Unit/ServiceCollectionExtensionsTests/AddProvider.cs
+++ b/tests/unit/Syrx.Commanders.Databases.Connectors.Extensions.Tests.Unit/ServiceCollectionExtensionsTests/AddProvider.cs
@@ -1,0 +1,41 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Syrx.Commanders.Databases.Tests.Extensions;
+using System.Data.Common;
+using static Xunit.Assert;
+
+namespace Syrx.Commanders.Databases.Connectors.Extensions.Tests.Unit.ServiceCollectionExtensionsTests
+{
+    public class AddProvider
+    {
+        private readonly IServiceCollection _services;
+
+        public AddProvider()
+        {
+            _services = new ServiceCollection();
+        }
+
+        [Fact]
+        public void NullProviderThrowsArgumentNullException()
+        {
+            var result = Throws<ArgumentNullException>(() => _services.AddProvider(null));
+            result.HasMessage("The DbProviderFactory delegate cannot be null. (Parameter 'providerFactory')");
+        }
+
+        [Fact]
+        public void Successfully()
+        {
+            var connection = new Mock<DbConnection>();
+            var dbProviderFactory = new Mock<DbProviderFactory>();
+            dbProviderFactory.Setup(x => x.CreateConnection()).Returns(connection.Object);
+
+            Func<DbProviderFactory> factory = () => dbProviderFactory.Object;
+            var result = _services.AddProvider(factory);
+
+            var provider = _services.BuildServiceProvider();
+            var resolved = provider.GetService<Func<DbProviderFactory>>();
+            NotNull(resolved);
+            Same(factory, resolved);
+        }
+    }    
+}

--- a/tests/unit/Syrx.Commanders.Databases.Settings.Extensions.Json.Tests.Unit/JsonFileFixture.cs
+++ b/tests/unit/Syrx.Commanders.Databases.Settings.Extensions.Json.Tests.Unit/JsonFileFixture.cs
@@ -19,9 +19,9 @@ namespace Syrx.Commanders.Databases.Settings.Extensions.Json.Tests.Unit
             ConfigurationBuilder = new ConfigurationBuilder();
         }
 
-        public string WriteToFile(CommanderSettings options)
+        public string WriteToFile(CommanderSettings options, string path = null)
         {
-            var path = FileName;
+            path = path ?? FileName;
             File.WriteAllText(path, options.Serialize());
             return path;
         }

--- a/tests/unit/Syrx.Commanders.Databases.Settings.Extensions.Json.Tests.Unit/ServiceCollectionExtensionsTests/AddSyrxJsonFile.cs
+++ b/tests/unit/Syrx.Commanders.Databases.Settings.Extensions.Json.Tests.Unit/ServiceCollectionExtensionsTests/AddSyrxJsonFile.cs
@@ -19,7 +19,6 @@ namespace Syrx.Commanders.Databases.Settings.Extensions.Json.Tests.Unit.ServiceC
             // act
             services.AddSyrxJsonFile(builder, filename);
             
-
             // finalze build
             var configuration = builder.Build();
             var provider = services.BuildServiceProvider();
@@ -35,7 +34,9 @@ namespace Syrx.Commanders.Databases.Settings.Extensions.Json.Tests.Unit.ServiceC
             Single(resolved.Namespaces.Single().Types);
             Equal(settings.Namespaces.Single().Types.Single().Name, resolved.Namespaces.Single().Types.Single().Name);
             Equal(2, resolved.Namespaces.Single().Types.Single().Commands.Count);
+
+            Equivalent(settings, resolved);
             
-        }
+        }        
     }
 }

--- a/tests/unit/Syrx.Commanders.Databases.Settings.Extensions.Json.Tests.Unit/ServiceCollectionExtensionsTests/UseFile.cs
+++ b/tests/unit/Syrx.Commanders.Databases.Settings.Extensions.Json.Tests.Unit/ServiceCollectionExtensionsTests/UseFile.cs
@@ -1,0 +1,90 @@
+﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Syrx.Extensions;
+using static Xunit.Assert;
+
+namespace Syrx.Commanders.Databases.Settings.Extensions.Json.Tests.Unit.ServiceCollectionExtensionsTests
+{
+    public class UseFile(JsonFileFixture fixture) : IClassFixture<JsonFileFixture>
+    {
+
+        [Fact]
+        public void UseFileOverload()
+        {
+            var fileName = $"syrx.settings.file-overload.{DateTime.UtcNow.ToString("yyMMddHH")}.json";
+            var services = fixture.Services;
+            var builder = fixture.ConfigurationBuilder;
+
+            // write file
+            var settings = fixture.GetTestOptions<UseFile>();
+            var filename = fixture.WriteToFile(settings, fileName);
+
+            services.UseSyrx(a => a.UseFile(filename, builder));
+
+            var provider = services.BuildServiceProvider();
+
+            var configuration = builder.Build();
+            var resolved = configuration.Get<CommanderSettings>();
+
+            NotNull(resolved);
+
+            Equivalent(settings, resolved);
+        }
+
+        //[Fact]
+        //public void IntegratesWithSettings()
+        //{
+        //    var fileName = $"syrx.settings.integration.{DateTime.UtcNow.ToString("yyMMddHH")}.json";
+        //    var services = fixture.Services;
+        //    //var builder = fixture.ConfigurationBuilder;
+        //    var builder = new ConfigurationBuilder();
+
+        //    // write file
+        //    var settings = fixture.GetTestOptions<AddSyrxJsonFile>();
+        //    var filename = fixture.WriteToFile(settings, fileName);
+
+        //    var connector = new Mock<DbProviderFactory>().Object;
+
+        //    //services.UseSyrx(a => a                
+        //    //    .UseConnector(() => connector, b => b
+        //    //        .AddCommand(c => c
+        //    //            .ForType<AddSyrxJsonFile>(d => d
+        //    //                .ForMethod(nameof(IntegratesWithSettings), e => e
+        //    //                    .UseConnectionAlias("test-alias-2")
+        //    //                    .UseCommandText("select 1/0;")))))
+        //    //    //.UseFile(filename, builder)
+        //    //    );
+
+        //    services.UseSyrx(a => a.UseFile(filename, builder));
+
+        //    var provider = services.BuildServiceProvider();
+
+        //    var configuration = builder.Build();
+        //    var resolved = configuration.Get<CommanderSettings>();
+
+
+        //    //var commanderSettings = provider.GetRequiredService<Syrx.Commanders.Databases.Settings.ICommanderSettings>();
+        //    //NotNull(commanderSettings);
+
+        //    resolved.PrintAsJson();
+        //    //commanderSettings.PrintAsJson();
+
+        //    var method = resolved.Namespaces.Single().Types.Single().Commands.First().Key;
+        //    Equal("Method1", method);
+        //    method.PrintAsJson();
+
+        //    var reader = provider.GetRequiredService<Syrx.Commanders.Databases.Settings.Readers.IDatabaseCommandReader>();
+        //    var method1 = reader.GetCommand(typeof(AddSyrxJsonFile), "Method1");
+        //    var method2 = reader.GetCommand(typeof(AddSyrxJsonFile), "Method2");
+
+
+
+        //    NotNull(resolved);
+
+        //    Equivalent(settings, resolved);
+        //    //Equivalent(settings, commanderSettings);
+        //    //Equivalent(resolved, commanderSettings);
+        //}
+
+    }
+}

--- a/tests/unit/Syrx.Commanders.Databases.Settings.Extensions.Json.Tests.Unit/Syrx.Commanders.Databases.Settings.Extensions.Json.Tests.Unit.csproj
+++ b/tests/unit/Syrx.Commanders.Databases.Settings.Extensions.Json.Tests.Unit/Syrx.Commanders.Databases.Settings.Extensions.Json.Tests.Unit.csproj
@@ -20,6 +20,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>
@@ -28,6 +29,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\..\src\Syrx.Commanders.Databases.Connectors.Extensions\Syrx.Commanders.Databases.Connectors.Extensions.csproj" />
     <ProjectReference Include="..\..\..\src\Syrx.Commanders.Databases.Settings.Extensions.Json\Syrx.Commanders.Databases.Settings.Extensions.Json.csproj" />
     <ProjectReference Include="..\..\..\src\Syrx.Commanders.Databases.Settings.Extensions\Syrx.Commanders.Databases.Settings.Extensions.csproj" />
     <ProjectReference Include="..\..\..\src\Syrx.Commanders.Databases.Settings\Syrx.Commanders.Databases.Settings.csproj" />

--- a/tests/unit/Syrx.Commanders.Databases.Settings.Extensions.Xml.Tests.Unit/ServiceCollectionExtensionsTests/AddSyrxXmlFile.cs
+++ b/tests/unit/Syrx.Commanders.Databases.Settings.Extensions.Xml.Tests.Unit/ServiceCollectionExtensionsTests/AddSyrxXmlFile.cs
@@ -33,7 +33,7 @@ namespace Syrx.Commanders.Databases.Settings.Extensions.Xml.Tests.Unit.ServiceCo
 
             // assertions
             NotNull(resolved);
-            //Equivalent(settings, resolved);
+            Equivalent(settings, resolved);
 
             Equal(settings.Connections, resolved.Connections);
             Single(resolved.Namespaces);
@@ -49,8 +49,7 @@ namespace Syrx.Commanders.Databases.Settings.Extensions.Xml.Tests.Unit.ServiceCo
             var services = fixture.Services;
             var builder = fixture.ConfigurationBuilder;
             const string path = "syrx.settings.xml";
-            services.AddSyrxXmlFile(builder, path); 
-
+            services.AddSyrxXmlFile(builder, path);
 
             // finalze build
             var configuration = builder.Build();

--- a/tests/unit/Syrx.Commanders.Databases.Settings.Extensions.Xml.Tests.Unit/ServiceCollectionExtensionsTests/UseFile.cs
+++ b/tests/unit/Syrx.Commanders.Databases.Settings.Extensions.Xml.Tests.Unit/ServiceCollectionExtensionsTests/UseFile.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Syrx.Extensions;
+using static Xunit.Assert;
+
+namespace Syrx.Commanders.Databases.Settings.Extensions.Xml.Tests.Unit.ServiceCollectionExtensionsTests
+{
+    public class UseFile(XmlFileFixture fixture) : IClassFixture<XmlFileFixture>
+    {
+
+        [Fact]
+        public void UseFileOverload()
+        {
+            var fileName = $"syrx.settings.file-overload.{DateTime.UtcNow.ToString("yyMMddHH")}.json";
+            var services = fixture.Services;
+            var builder = fixture.ConfigurationBuilder;
+
+            // write file
+            var settings = fixture.GetTestOptions<UseFile>();
+            var filename = fixture.WriteToFile(settings, fileName);
+
+            services.UseSyrx(a => a.UseFile(filename, builder));
+
+            var provider = services.BuildServiceProvider();
+
+            var configuration = builder.Build();
+            var resolved = configuration.Get<CommanderSettings>();
+
+            NotNull(resolved);
+
+            Equivalent(settings, resolved);
+        }
+
+
+
+
+    }
+}

--- a/tests/unit/Syrx.Commanders.Databases.Settings.Extensions.Xml.Tests.Unit/Syrx.Commanders.Databases.Settings.Extensions.Xml.Tests.Unit.csproj
+++ b/tests/unit/Syrx.Commanders.Databases.Settings.Extensions.Xml.Tests.Unit/Syrx.Commanders.Databases.Settings.Extensions.Xml.Tests.Unit.csproj
@@ -1,46 +1,47 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>disable</Nullable>
+	<PropertyGroup>
+		<TargetFramework>net8.0</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>disable</Nullable>
 
-    <IsPackable>false</IsPackable>
-    <IsTestProject>true</IsTestProject>
-  </PropertyGroup>
+		<IsPackable>false</IsPackable>
+		<IsTestProject>true</IsTestProject>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="9.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="xunit" Version="2.9.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="coverlet.collector" Version="6.0.2">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Xml" Version="9.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Options" Version="9.0.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+		<PackageReference Include="xunit" Version="2.9.2" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\src\Syrx.Commanders.Databases.Settings.Extensions.Xml\Syrx.Commanders.Databases.Settings.Extensions.Xml.csproj" />
-    <ProjectReference Include="..\..\..\src\Syrx.Commanders.Databases.Settings.Extensions\Syrx.Commanders.Databases.Settings.Extensions.csproj" />
-    <ProjectReference Include="..\..\..\src\Syrx.Commanders.Databases.Settings\Syrx.Commanders.Databases.Settings.csproj" />
-	<ProjectReference Include="..\Syrx.Commanders.Databases.Tests.Extensions\Syrx.Commanders.Databases.Tests.Extensions.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\..\..\src\Syrx.Commanders.Databases.Connectors.Extensions\Syrx.Commanders.Databases.Connectors.Extensions.csproj" />
+		<ProjectReference Include="..\..\..\src\Syrx.Commanders.Databases.Settings.Extensions.Xml\Syrx.Commanders.Databases.Settings.Extensions.Xml.csproj" />
+		<ProjectReference Include="..\..\..\src\Syrx.Commanders.Databases.Settings.Extensions\Syrx.Commanders.Databases.Settings.Extensions.csproj" />
+		<ProjectReference Include="..\..\..\src\Syrx.Commanders.Databases.Settings\Syrx.Commanders.Databases.Settings.csproj" />
+		<ProjectReference Include="..\Syrx.Commanders.Databases.Tests.Extensions\Syrx.Commanders.Databases.Tests.Extensions.csproj" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <Using Include="Xunit" />
-  </ItemGroup>
+	<ItemGroup>
+		<Using Include="Xunit" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <None Update="syrx.settings.xml">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
+	<ItemGroup>
+		<None Update="syrx.settings.xml">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</None>
+	</ItemGroup>
 
 </Project>

--- a/tests/unit/Syrx.Commanders.Databases.Settings.Extensions.Xml.Tests.Unit/XmlFileFixture.cs
+++ b/tests/unit/Syrx.Commanders.Databases.Settings.Extensions.Xml.Tests.Unit/XmlFileFixture.cs
@@ -20,9 +20,9 @@ namespace Syrx.Commanders.Databases.Settings.Extensions.Xml.Tests.Unit
             ConfigurationBuilder = new ConfigurationBuilder();
         }
 
-        public string WriteToFile(CommanderSettings options)
+        public string WriteToFile(CommanderSettings options, string path = null)
         {
-            var path = FileName;
+            path = path ?? FileName;
             WriteXml(path, options);
 
             return path;

--- a/tests/unit/Syrx.Commanders.Databases.Settings.Readers.Tests.Unit/Syrx.Commanders.Databases.Settings.Readers.Tests.Unit.csproj
+++ b/tests/unit/Syrx.Commanders.Databases.Settings.Readers.Tests.Unit/Syrx.Commanders.Databases.Settings.Readers.Tests.Unit.csproj
@@ -16,6 +16,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">


### PR DESCRIPTION
* Syrx.Commanders.Databases.Settings.Readers - removed redundant references.
* Syrx.Commander.Databases.Settings.Extensions - marked Evalute method as private.
* Syrx.Commanders.Databases.Settings.Extensions.Json - added `UseFile` extension method to provide better syntactic support.
* Syrx.Commanders.Databases.Settings.Extensions.Xml - added `UseFile` extension method to provide better syntactic support.