### PR TITLE
added support to the tests for .net 9.0

### DIFF
--- a/tests/integration/Syrx.Commanders.Databases.Tests.Integration.Models/Syrx.Commanders.Databases.Tests.Integration.Models.csproj
+++ b/tests/integration/Syrx.Commanders.Databases.Tests.Integration.Models/Syrx.Commanders.Databases.Tests.Integration.Models.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>disable</Nullable>
   </PropertyGroup>

--- a/tests/integration/Syrx.Commanders.Databases.Tests.Integration/Syrx.Commanders.Databases.Tests.Integration.csproj
+++ b/tests/integration/Syrx.Commanders.Databases.Tests.Integration/Syrx.Commanders.Databases.Tests.Integration.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>disable</Nullable>
 

--- a/tests/unit/Syrx.Commanders.Databases.Builders.Tests.Unit/Syrx.Commanders.Databases.Builders.Tests.Unit.csproj
+++ b/tests/unit/Syrx.Commanders.Databases.Builders.Tests.Unit/Syrx.Commanders.Databases.Builders.Tests.Unit.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>disable</Nullable>
 

--- a/tests/unit/Syrx.Commanders.Databases.Connectors.Extensions.Tests.Unit/Syrx.Commanders.Databases.Connectors.Extensions.Tests.Unit.csproj
+++ b/tests/unit/Syrx.Commanders.Databases.Connectors.Extensions.Tests.Unit/Syrx.Commanders.Databases.Connectors.Extensions.Tests.Unit.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>disable</Nullable>
 

--- a/tests/unit/Syrx.Commanders.Databases.Connectors.Tests.Unit/Syrx.Commanders.Databases.Connectors.Tests.Unit.csproj
+++ b/tests/unit/Syrx.Commanders.Databases.Connectors.Tests.Unit/Syrx.Commanders.Databases.Connectors.Tests.Unit.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>disable</Nullable>
 

--- a/tests/unit/Syrx.Commanders.Databases.Extensions.Tests.Unit/Syrx.Commanders.Databases.Extensions.Tests.Unit.csproj
+++ b/tests/unit/Syrx.Commanders.Databases.Extensions.Tests.Unit/Syrx.Commanders.Databases.Extensions.Tests.Unit.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>disable</Nullable>
 

--- a/tests/unit/Syrx.Commanders.Databases.Settings.Extensions.Json.Tests.Unit/Syrx.Commanders.Databases.Settings.Extensions.Json.Tests.Unit.csproj
+++ b/tests/unit/Syrx.Commanders.Databases.Settings.Extensions.Json.Tests.Unit/Syrx.Commanders.Databases.Settings.Extensions.Json.Tests.Unit.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>disable</Nullable>
 

--- a/tests/unit/Syrx.Commanders.Databases.Settings.Extensions.Tests.Unit/Syrx.Commanders.Databases.Settings.Extensions.Tests.Unit.csproj
+++ b/tests/unit/Syrx.Commanders.Databases.Settings.Extensions.Tests.Unit/Syrx.Commanders.Databases.Settings.Extensions.Tests.Unit.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>disable</Nullable>
 

--- a/tests/unit/Syrx.Commanders.Databases.Settings.Extensions.Xml.Tests.Unit/Syrx.Commanders.Databases.Settings.Extensions.Xml.Tests.Unit.csproj
+++ b/tests/unit/Syrx.Commanders.Databases.Settings.Extensions.Xml.Tests.Unit/Syrx.Commanders.Databases.Settings.Extensions.Xml.Tests.Unit.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFrameworks>net8.0;net9.0</TargetFrameworks>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>disable</Nullable>
 

--- a/tests/unit/Syrx.Commanders.Databases.Settings.Readers.Extensions.Tests.Unit/Syrx.Commanders.Databases.Settings.Readers.Extensions.Tests.Unit.csproj
+++ b/tests/unit/Syrx.Commanders.Databases.Settings.Readers.Extensions.Tests.Unit/Syrx.Commanders.Databases.Settings.Readers.Extensions.Tests.Unit.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>disable</Nullable>
 

--- a/tests/unit/Syrx.Commanders.Databases.Settings.Readers.Tests.Unit/Syrx.Commanders.Databases.Settings.Readers.Tests.Unit.csproj
+++ b/tests/unit/Syrx.Commanders.Databases.Settings.Readers.Tests.Unit/Syrx.Commanders.Databases.Settings.Readers.Tests.Unit.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>disable</Nullable>
 

--- a/tests/unit/Syrx.Commanders.Databases.Settings.Tests.Unit/Syrx.Commanders.Databases.Settings.Tests.Unit.csproj
+++ b/tests/unit/Syrx.Commanders.Databases.Settings.Tests.Unit/Syrx.Commanders.Databases.Settings.Tests.Unit.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>disable</Nullable>
 

--- a/tests/unit/Syrx.Commanders.Databases.Tests.Extensions/Syrx.Commanders.Databases.Tests.Extensions.csproj
+++ b/tests/unit/Syrx.Commanders.Databases.Tests.Extensions/Syrx.Commanders.Databases.Tests.Extensions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/tests/unit/Syrx.Commanders.Databases.Tests.Unit/Syrx.Commanders.Databases.Tests.Unit.csproj
+++ b/tests/unit/Syrx.Commanders.Databases.Tests.Unit/Syrx.Commanders.Databases.Tests.Unit.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 


### PR DESCRIPTION
This pull request updates all test project files to support both .NET 8.0 and .NET 9.0, instead of only .NET 8.0. This change ensures that the tests will run against both framework versions, improving compatibility and future-proofing the test suite.

Framework compatibility updates:

* Changed the `TargetFramework` property to `TargetFrameworks` in all test `.csproj` files, specifying both `net8.0` and `net9.0` as supported frameworks. [[1]](diffhunk://#diff-0b39f3dd354dd1d15c2ec578281c09537d740a98797350ecb643ddddb12429fdL4-R4) [[2]](diffhunk://#diff-bc2bf215eca854f88216151f5e842ed2eb05b3ae30da0b8611871383c6bcf5efL4-R4) [[3]](diffhunk://#diff-99b91563bfcd4d4c2a74228d580ebdbc9bfff6226cbcae6755e13d3dafce9a33L4-R4) [[4]](diffhunk://#diff-2099fdd7df1e7590917d92b4e9eba70d3fe4bc81a1a9346483d4b1c3f8e29cefL4-R4) [[5]](diffhunk://#diff-94fefadb808d47e2d40fd5e0129436788675efbf387e50fb3f5600c0fa25e487L4-R4) [[6]](diffhunk://#diff-4e1583d61300a2f9579c00fa7f615ed0710729571f4b4d163a2126025754265fL4-R4) [[7]](diffhunk://#diff-53e4f7d8ba8a2643bdb41d7229882c57fb6557ae9336e99f9282cb522de28081L4-R4) [[8]](diffhunk://#diff-defe21f7e750e3d24ebb7ba8c06d04d12b55aa5257d5925b465e3fa35f86b709L4-R4) [[9]](diffhunk://#diff-335a12d9619f5db57a688a504fca7fdf9e11bbd6ebe56d10b67450ac25ec37c3L4-R4) [[10]](diffhunk://#diff-c27aaeb1e193bcfc43d3010c360b380c9e5917e86e2efa50e0adcf9bb74234ceL4-R4) [[11]](diffhunk://#diff-2fe1ff6020da7fc5b95f868e43522fc0e79de9045181231ae701269a981bec5cL4-R4) [[12]](diffhunk://#diff-64ec5b65ce06a7cd644c0b800d894c22beb452bdead7038f39109ad7dbfeb034L4-R4) [[13]](diffhunk://#diff-b8306a21c909eb65dc3fb4a8553196583adbbd80a2e789c41d38a7959b8a4a94L4-R4) [[14]](diffhunk://#diff-ab2c5fe30a28d32fa3577f9a74fa9f78ab6055522376e83580d70d45ad606a65L4-R4)