### PR TITLE
ci: align publish workflow to net10

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,7 +44,7 @@ jobs:
       contents: read # Required for repository checkout.
     strategy:
       matrix:
-        dotnet-version: [ '8.0.x' ]
+        dotnet-version: [ '10.0.x' ]
         
     steps:    
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -79,6 +79,8 @@ jobs:
       # Install the .NET SDK indicated in the global.json file
       - name: Setup .NET
         uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
+        with:
+          dotnet-version: 10.0.x
 
       # Download the NuGet package created in the previous job
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -96,6 +98,8 @@ jobs:
       run: git submodule update --init --recursive
     - name: Setup .NET
       uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
+      with:
+        dotnet-version: 10.0.x
     - name: Run tests
       run: dotnet test --configuration Release
 
@@ -116,6 +120,8 @@ jobs:
       # Install the .NET SDK indicated in the global.json file
       - name: Setup .NET Core
         uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
+        with:
+          dotnet-version: 10.0.x
 
       # Publish all NuGet packages to NuGet.org
       # Use --skip-duplicate to prevent errors if a package with the same version already exists.


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow to use .NET 10.0.x instead of 8.0.x throughout the `publish.yml` file. The main goal is to ensure that all build, test, and publish steps are run with the latest .NET SDK version.

.NET SDK version updates:

* Updated the build matrix to use `dotnet-version: 10.0.x` instead of `8.0.x` for all jobs in `.github/workflows/publish.yml`.
* Added explicit `dotnet-version: 10.0.x` configuration to all `actions/setup-dotnet` steps, ensuring consistency across build, test, and publish stages. [[1]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7R82-R83) [[2]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7R101-R102) [[3]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7R123-R124)